### PR TITLE
Passing LDFLAGS to shared lib

### DIFF
--- a/gridgen/makefile.in
+++ b/gridgen/makefile.in
@@ -115,7 +115,7 @@ libgridgen.a: $(HEADERS) triangle.o $(LIBOBJS)
 
 libgridgen.so: $(HEADERS) triangle.t $(SHLIBOBJS)
 	rm -f $@
-	$(CC) -shared -o $@ $(SHLIBOBJS) triangle.t $(LIBS)
+	$(CC) -shared -o $@ $(SHLIBOBJS) triangle.t $(LDFLAGS) $(LIBS)
 
 triangle.o: triangle.c
 	$(CC) -c -DTRILIBRARY $(CFLAGS_TRIANGLE) -I. triangle.c


### PR DESCRIPTION
This change is needed to compile the shared lib properly.
